### PR TITLE
CHANGE(rawx): Move run directory from /run/rawx to /run/oio/sds

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Rawx is the storage service and is implemented as an apache webdav repository mo
 | `openio_rawx_mpm_start_servers` | `1` |  sets the number of child server processes created on startup |
 | `openio_rawx_mpm_threads_per_child` | `256` | sets the maximum configured value for ThreadsPerChild for the lifetime of the process |
 | `openio_rawx_namespace` | `"/var/lib/oio/sds/{{ openio_rawx_namespace }}/{{ openio_rawx_servicename }}"` | Namespace |
-| `openio_rawx_pid_directory` | `"/run/rawx/{{ openio_rawx_namespace }}/{{ openio_rawx_servicename }}"` | Folder for pid file |
+| `openio_rawx_pid_directory` | `"/run/oio/sds/{{ openio_rawx_namespace }}"` | Folder for pid file |
 | `openio_rawx_provision_only` | `false` | Provision only without restarting services |
 | `openio_rawx_serviceid` | `"0"` | ID in gridinit |
 | `openio_rawx_volume` | `"/var/lib/oio/sds/{{ openio_rawx_namespace }}/{{ openio_rawx_servicename }}"` | Path to store data |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,7 +15,7 @@ openio_rawx_gridinit_file_prefix: ""
 
 openio_rawx_golang: false
 
-openio_rawx_pid_directory: "/run/rawx/{{ openio_rawx_namespace }}/{{ openio_rawx_servicename }}"
+openio_rawx_pid_directory: "/run/oio/sds/{{ openio_rawx_namespace }}"
 # MPM worker
 openio_rawx_mpm_max_requests_per_child: 0
 openio_rawx_mpm_max_spare_threads: 256

--- a/templates/rawx.conf.j2
+++ b/templates/rawx.conf.j2
@@ -16,7 +16,7 @@ LoadModule logio_module        {{ rawx_httpd_moduledir }}/mod_logio.so
 Alias / /x/
 
 Listen          {{ openio_rawx_bind_address }}:{{ openio_rawx_bind_port }}
-PidFile         {{ openio_rawx_pid_directory }}/{{ openio_rawx_namespace }}-{{ openio_rawx_servicename }}-httpd.pid
+PidFile         {{ openio_rawx_pid_directory }}/{{ openio_rawx_servicename }}-httpd.pid
 ServerRoot      /var/lib/oio/sds/{{ openio_rawx_namespace }}/coredump
 ServerName      localhost
 ServerSignature Off


### PR DESCRIPTION
 ##### SUMMARY
Change erroneous run directory from /run/rawx/$namespace/$service
to /run/oio/sds/$namespace to match OpenIO path-style.

 ##### IMPACT
PID change directory, this should be reported in the logrotate
configuration to match logfile rotation with this path.
(previous path wasn't rotated anyway)