### PR TITLE
FEATURE(rawx): Add a conscience slots managment

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Rawx is the storage service and is implemented as an apache webdav repository mo
 | `openio_rawx_pid_directory` | `"/run/oio/sds/{{ openio_rawx_namespace }}"` | Folder for pid file |
 | `openio_rawx_provision_only` | `false` | Provision only without restarting services |
 | `openio_rawx_serviceid` | `"0"` | ID in gridinit |
+| `openio_rawx_slots` | `[rawx]` | The service's slot in conscience |
 | `openio_rawx_volume` | `"/var/lib/oio/sds/{{ openio_rawx_namespace }}/{{ openio_rawx_servicename }}"` | Path to store data |
 
 ## Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,4 +33,9 @@ openio_rawx_compression: "off"
 openio_rawx_location: "{{ ansible_hostname }}.{{ openio_rawx_serviceid }}"
 openio_rawx_location_ending: ""
 openio_rawx_provision_only: false
+
+openio_rawx_slots:
+  "{{ [ openio_rawx_type, openio_rawx_type ~ '-' ~ openio_rawx_location.split('.')[:-2] | join('-') ] \
+  if openio_rawx_location.split('.') | length > 2 \
+  else [ openio_rawx_type ] }}"
 ...

--- a/templates/watch-rawx.yml.j2
+++ b/templates/watch-rawx.yml.j2
@@ -8,9 +8,9 @@ location: {{ openio_rawx_location | replace(".", "-") }}
 {% else %}
 {% if  openio_rawx_location_ending %}
 {% if openio_rawx_location_ending == 'device_inode' %}
-location: {{ openio_rawx_location }}.{{ openio_rawx_volume | device_inode }} 
+location: {{ openio_rawx_location }}.{{ openio_rawx_volume | device_inode }}
 {% elif openio_rawx_location_ending == 'mount_point' %}
-location: {{ openio_rawx_location }}.{{ openio_rawx_volume.split('/')[-1] }} 
+location: {{ openio_rawx_location }}.{{ openio_rawx_volume.split('/')[-1] }}
 {% endif %}
 {% else %}
 location: {{ openio_rawx_location }}
@@ -22,4 +22,6 @@ stats:
   - {type: volume, path: {{ openio_rawx_volume }}}
   - {type: rawx, path: /stat}
   - {type: system}
+slots:
+  {{ openio_rawx_slots | to_nice_yaml | indent(2) }}
 ...

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,10 +1,10 @@
 ---
 openio_rawx_sysconfig_dir: "/etc/oio/sds/{{ openio_rawx_namespace }}"
-openio_rawx_servicename: "rawx-{{ openio_rawx_serviceid }}"
-
+openio_rawx_servicename: "rawx-{{ openio_rawx_serviceid }}"
+openio_rawx_type: rawx
 #openio_rawx_definition_file: >
 #  "{{ openio_rawx_sysconfig_dir }}/
-#  {{ openio_rawx_servicename }}/{{ openio_rawx_servicename }}.conf"
+#  {{ openio_rawx_servicename }}/{{ openio_rawx_servicename }}.conf"
 #openio_rawx_gridinit_dir: "/etc/gridinit.d/{{ openio_rawx_namespace }}"
 
 ...


### PR DESCRIPTION
 ##### ISSUE TYPE
- Feature

 ##### SUMMARY
Add slots for multisite deployments

 ##### SCOPE (skeleton only)
- rawx

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
Currently slots are unmanaged.
This commit add a default slot (servicetype's name).
For location superior to 2, a slot is added based on the first two locations

examples:
location:
  - host.id            slots => [rawx]
  - site.host.id       slots => [rawx, rawx-site]
  - region.site.host.id  slots => [rawx, rawx-region-site]