### PR TITLE
CHANGE(rawx): Ensure service is started or restarted at the end of role

### DIFF
--- a/docker-tests/test.yml
+++ b/docker-tests/test.yml
@@ -4,18 +4,17 @@
   become: true
   vars:
     NS: TRAVIS
+    openio_bootstrap: true
   roles:
     - role: users
     - role: repo
       openio_repository_no_log: false
-      openio_repository_products:
-        sds:
-          release: "18.10"
-    - role: namespace
-      openio_namespace_name: "{{ NS }}"
+      openio_repository_mirror_host: mirror2.openio.io
     - role: gridinit
       openio_gridinit_namespace: "{{ NS }}"
       openio_gridinit_per_ns: true
+    - role: namespace
+      openio_namespace_name: "{{ NS }}"
     - role: role_under_test
       openio_rawx_namespace: "{{ NS }}"
       openio_rawx_serviceid: "0"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -66,12 +66,37 @@
   command: gridinit_cmd reload
   changed_when: false
 
-- name: restart rawx
+- name: "restart rawx to apply the new configuration"
   shell: |
     gridinit_cmd reload
     gridinit_cmd restart  {{ openio_rawx_namespace }}-{{ openio_rawx_servicename }}
+  register: _restart_rawx
   when:
-    - _rawx_conf.changed
+    - _rawx_conf is changed
     - not openio_rawx_provision_only
   tags: configure
+
+- block:
+    - name: "Ensure rawx is started"
+      command: gridinit_cmd start {{ openio_rawx_namespace }}-{{ openio_rawx_servicename }}
+      register: _start_rawx
+      changed_when: '"Success" in _start_rawx.stdout'
+      when:
+        - not openio_rawx_provision_only
+        - _restart_rawx is skipped
+      tags: configure
+
+    - name: check rawx
+      uri:
+        url: "http://{{ openio_rawx_bind_address }}:{{ openio_rawx_bind_port }}/info"
+        return_content: true
+        status_code: 200
+      register: _rawx_check
+      retries: 3
+      delay: 5
+      until: _rawx_check is success
+      changed_when: false
+      when:
+        - not openio_rawx_provision_only
+  when: openio_bootstrap | d(false)
 ...


### PR DESCRIPTION
 ##### SUMMARY
Until 18.10, a voluntarily stopped service was not revived by a reproviosionning.

In 19.04, the `maintenance` mode becomes the default mode.

To avoid having to force (ie. deletion of conf files) the restart of a service delivered first, by error, in maintenance mode: We have to make sure that service is started and it works well at the end of the role.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION