### PR TITLE
CHANGE(rawx): Change `grid_fsync` from enabled to disabled by default…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,7 +25,7 @@ openio_rawx_mpm_threads_per_child: 256
 
 openio_rawx_hash_width: 3
 openio_rawx_hash_depth: 1
-openio_rawx_fsync: enabled
+openio_rawx_fsync: disabled
 openio_rawx_fsync_dir: enabled
 openio_rawx_compression: "off"
 


### PR DESCRIPTION
… OS-378

 ##### SUMMARY

Disabling fsync greatly improves chunk write performance but also reduce durability.
On EC platforms, it’s an acceptable tradeoff.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION