### PR TITLE
CHANGE(rawx): Optimize check interval

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -96,8 +96,8 @@
         return_content: true
         status_code: 200
       register: _rawx_check
-      retries: 3
-      delay: 5
+      retries: 30
+      delay: 0.5
       until: _rawx_check is success
       changed_when: false
       tags: configure


### PR DESCRIPTION
 ##### SUMMARY

Previously, the service availability check would wait 5 seconds between
each attempt, meaning a service that would start shortly after the 1st failure would slow the play down 5 seconds. This performs the check more often (total timeout remains the same).

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION