### PR TITLE
CHANGE(rawx): Add flag to force package upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Rawx is the storage service and is implemented as an apache webdav repository mo
 | `openio_rawx_serviceid` | `"0"` | ID in gridinit |
 | `openio_rawx_slots` | `[rawx]` | The service's slot in conscience |
 | `openio_rawx_volume` | `"/var/lib/oio/sds/{{ openio_rawx_namespace }}/{{ openio_rawx_servicename }}"` | Path to store data |
+| `openio_rawx_package_upgrade` | `false` | Set the packages to the latest version (to be set in extra_vars) |
+
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,6 +35,7 @@ openio_rawx_location: "{{ openio_location_room | default ('') }}{{ openio_locati
   {{ openio_location_server | default (ansible_hostname ~ '.') }}{{ openio_rawx_serviceid }}"
 openio_rawx_location_ending: ""
 openio_rawx_provision_only: false
+openio_rawx_package_upgrade: "{{ openio_package_upgrade | d(false) }}"
 
 openio_rawx_slots:
   "{{ [ openio_rawx_type, openio_rawx_type ~ '-' ~ openio_rawx_location.split('.')[:-2] | join('-') ] \

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -2,7 +2,7 @@
 - name: Install packages
   package:
     name: "{{ pkg }}"
-    state: present
+    state: "{{ 'latest' if openio_rawx_package_upgrade else 'present' }}"
   with_items: "{{ rawx_packages }}"
   loop_control:
     loop_var: pkg

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -2,7 +2,7 @@
 - name: Install packages
   package:
     name: "{{ pkg }}"
-    state: present
+    state: "{{ 'latest' if openio_rawx_package_upgrade else 'present' }}"
   with_items: "{{ rawx_packages }}"
   loop_control:
     loop_var: pkg


### PR DESCRIPTION
 ##### SUMMARY

This is useful during upgrades, as it allows to update packages to the
latest version without requiring an external playbook/task.

To use this, simply provide the -e openio_package_upgrade=true argument

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION