### PR TITLE
CHANGE(rawx): Improve log format to log incoming bytes

### DIFF
--- a/templates/rawx.conf.j2
+++ b/templates/rawx.conf.j2
@@ -38,17 +38,12 @@ SetEnvIf Request_Method "PUT" log-cid-in=1
 SetEnvIf Request_Method "PUT" !log-cid-out
 SetEnvIf log-cid-in 0 !log-cid-in
 {% raw %}
-LogFormat "%{%b %d %T}t %{HOSTNAME}e %{INFO_SERVICES}e %{pid}P %{tid}P %{LOG_TYPE}e %{LEVEL}e %{Host}i %a:%{remote}p %m %>s %D %I %{x-oio-chunk-meta-container-id}i %{x-oio-req-id}i %U" log/cid-in
-LogFormat "%{%b %d %T}t %{HOSTNAME}e %{INFO_SERVICES}e %{pid}P %{tid}P %{LOG_TYPE}e %{LEVEL}e %{Host}i %a:%{remote}p %m %>s %D %O %{x-oio-chunk-meta-container-id}o %{x-oio-req-id}i %U" log/cid-out
+LogFormat "%{%b %d %T}t %{HOSTNAME}e %{INFO_SERVICES}e %{pid}P %{tid}P %{LOG_TYPE}e %{LEVEL}e %{Host}i %a:%{remote}p %m %>s %D %O %I - %{x-oio-req-id}i %U" log/req
 {% endraw %}
 ErrorLog /var/log/oio/sds/{{ openio_rawx_namespace }}/{{ openio_rawx_servicename }}/{{ openio_rawx_servicename }}-httpd-errors.log
 SetEnvIf Request_URI "/(stat|info)$" nolog=1
 
-SetEnvIf nolog 1 !log-cid-out
-SetEnvIf nolog 1 !log-cid-in
-
-CustomLog /var/log/oio/sds/{{ openio_rawx_namespace }}/{{ openio_rawx_servicename }}/{{ openio_rawx_servicename }}-httpd-access.log log/cid-out env=log-cid-out
-CustomLog /var/log/oio/sds/{{ openio_rawx_namespace }}/{{ openio_rawx_servicename }}/{{ openio_rawx_servicename }}-httpd-access.log log/cid-in  env=log-cid-in
+CustomLog /var/log/oio/sds/{{ openio_rawx_namespace }}/{{ openio_rawx_servicename }}/{{ openio_rawx_servicename }}-httpd-access.log log/req env=!nolog
 
 <IfModule worker.c>
 MaxRequestsPerChild {{ openio_rawx_mpm_max_requests_per_child }}


### PR DESCRIPTION
 ##### SUMMARY

This replaces the previously tricky to get and very rarely used field
"x-oio-chunk-meta-container-id" by the much more useful "bytes_in" stat.

See https://github.com/open-io/ansible-role-openio-rawx/pull/15

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION