### PR TITLE
CHANGE(rawx): log the request end time

### DIFF
--- a/templates/rawx.conf.j2
+++ b/templates/rawx.conf.j2
@@ -38,7 +38,7 @@ SetEnvIf Request_Method "PUT" log-cid-in=1
 SetEnvIf Request_Method "PUT" !log-cid-out
 SetEnvIf log-cid-in 0 !log-cid-in
 {% raw %}
-LogFormat "%{%b %d %T}t %{HOSTNAME}e %{INFO_SERVICES}e %{pid}P %{tid}P %{LOG_TYPE}e %{LEVEL}e %{Host}i %a:%{remote}p %m %>s %D %O %I - %{x-oio-req-id}i %U" log/req
+LogFormat "%{end:%b %d %T}t.%{end:usec_frac}t %{HOSTNAME}e %{INFO_SERVICES}e %{pid}P %{tid}P %{LOG_TYPE}e %{LEVEL}e %{Host}i %a:%{remote}p %m %>s %D %O %I - %{x-oio-req-id}i %U" log/req
 {% endraw %}
 ErrorLog /var/log/oio/sds/{{ openio_rawx_namespace }}/{{ openio_rawx_servicename }}/{{ openio_rawx_servicename }}-httpd-errors.log
 SetEnvIf Request_URI "/(stat|info)$" nolog=1


### PR DESCRIPTION
##### SUMMARY
Instead of logging the time the request started, be consistent with all other OpenIO SDS services, and log the time the request ended.

Also, to help matching log lines that do not carry a request ID, display the time with microseconds.

##### IMPACT
N/A

##### ADDITIONAL INFORMATION
N/A