### PR TITLE
BUGFIX/MINOR(rawx): Add missing tags install/configure

### DIFF
--- a/tasks/absent.yml
+++ b/tasks/absent.yml
@@ -6,7 +6,9 @@
     openio_rawx_bind_port: "{{ rx.ansible_facts._rawx.port }}"
     openio_rawx_serviceid: "{{ rx.ansible_facts._rawx.id }}"
     openio_rawx_volume: "{{ rx.ansible_facts._rawx.volume }}"
-
+  tags:
+    - install
+    - configure
 
 - name: absent - Remove configuration files
   file:
@@ -19,6 +21,7 @@
         {{ openio_rawx_servicename }}.conf"
     - dest: "{{ openio_rawx_sysconfig_dir }}/watch/{{ openio_rawx_servicename }}.yml"
   register: _rawx_conf
+  tags: configure
 
 - block:
     - name: absent - stop rawx to apply the new configuration
@@ -30,5 +33,5 @@
   when:
     - _rawx_conf is changed
     - not openio_rawx_provision_only
-
+  tags: configure
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,6 +26,9 @@
       state: "{{ item.1.state | d('present') }}"
   with_indexed_items: "{{ openio_rawx_instances }}"
   register: _rawx_properties
+  tags:
+    - install
+    - configure
 
 - block:
     - name: Ensure namespace directories exist
@@ -55,19 +58,23 @@
 
 - name: "Include tasks for rawx state"
   include_tasks: "{{ rx.ansible_facts._rawx.state }}.yml"
-  tags: configure
+  tags:
+    - install
+    - configure
   with_items: "{{ _rawx_properties.results }}"
   loop_control:
     loop_var: rx
 
 - name: "Reload gridinit to apply the new configuration"
   shell: gridinit_cmd reload
+  tags: configure
   when:
     - not openio_rawx_provision_only
     - need_reload | default(false)
 
 - name: "restart rawx to apply the new configuration"
   shell: gridinit_cmd restart  {{ openio_rawx_namespace }}-{{ openio_rawx_servicename }}
+  tags: configure
   with_items: "{{ _rawx_properties.results }}"
   when:
     - item.ansible_facts._rawx.state == "present"

--- a/tasks/offline.yml
+++ b/tasks/offline.yml
@@ -7,8 +7,11 @@
     openio_rawx_serviceid: "{{ rx.ansible_facts._rawx.id }}"
     openio_rawx_volume: "{{ rx.ansible_facts._rawx.volume }}"
     openio_rawx_state: "{{ rx.ansible_facts._rawx.state }}"
+  tags:
+    - install
+    - configure
 
-- name: offline -Generate configuration files
+- name: offline - Generate configuration files
   template:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
@@ -20,6 +23,7 @@
       dest: "{{ openio_rawx_gridinit_dir }}/{{ openio_rawx_gridinit_file_prefix }}\
         {{ openio_rawx_servicename }}.conf"
   register: _rawx_conf
+  tags: configure
 
 - block:
     - name: offline - stop rawx to apply the new configuration
@@ -31,4 +35,5 @@
   when:
     - _rawx_conf is changed
     - not openio_rawx_provision_only
+  tags: configure
 ...

--- a/tasks/present.yml
+++ b/tasks/present.yml
@@ -8,6 +8,9 @@
     openio_rawx_serviceid: "{{ rx.ansible_facts._rawx.id }}"
     openio_rawx_volume: "{{ rx.ansible_facts._rawx.volume }}"
     openio_rawx_state: "{{ rx.ansible_facts._rawx.state }}"
+  tags:
+    - install
+    - configure
 
 - name: present - Ensure directories exists
   file:
@@ -22,6 +25,7 @@
     - path: "/var/log/oio/sds/{{ openio_rawx_namespace }}/{{ openio_rawx_servicename }}"
       owner: "{{ syslog_user }}"
       mode: "0770"
+  tags: install
 
 - name: present - Generate configuration files
   template:
@@ -40,6 +44,7 @@
     - src: "watch-rawx.yml.j2"
       dest: "{{ openio_rawx_sysconfig_dir }}/watch/{{ openio_rawx_servicename }}.yml"
   register: _rawx_conf
+  tags: configure
 
 - block:
     - name: present - Set properties
@@ -48,4 +53,5 @@
   when:
     - _rawx_conf is changed
     - not openio_rawx_provision_only
+  tags: configure
 ...


### PR DESCRIPTION
 ##### SUMMARY

The tags `install` and `configure` are broken since the commit 389b3ac

 ##### IMPACT
 N/A

 ##### ADDITIONAL INFORMATION