### PR TITLE
BUGFIX/MEDIUM(SDS): Define internal variables for loop interation instead of rewrite role's defaults

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,18 @@
 # .travis.yml Execution script for role tests on Travis-CI
 ---
-dist: xenial
+dist: bionic
 sudo: required
 
 env:
   global:
-    - ANSIBLE_VERSION=2.5
+    - ANSIBLE_VERSION=2.9
   matrix:
     - DISTRIBUTION: centos
       VERSION: 7
 #    - DISTRIBUTION: centos
 #      VERSION: 8
-    - DISTRIBUTION: ubuntu
-      VERSION: 16.04
+#    - DISTRIBUTION: ubuntu
+#      VERSION: 16.04
     - DISTRIBUTION: ubuntu
       VERSION: 18.04
 #    - DISTRIBUTION: debian
@@ -20,6 +20,10 @@ env:
 
 services:
   - docker
+
+language: python
+python:
+  - "3.6"
 
 before_install:
   # Install latest Git

--- a/docker-tests/README.md
+++ b/docker-tests/README.md
@@ -1,20 +1,9 @@
 # Docker test environment
 
-1. Fetch the test branch: `git fetch origin docker-tests`
-2. Create a Git worktree for the test code: `git worktree add docker-tests docker-tests`. This will create a directory `docker-tests/`
-3. The script `docker-tests.sh` will create a Docker container, and apply this role from a playbook `<test.yml>`. The Docker images are configured for testing Ansible roles and are published at <https://hub.docker.com/r/cdelgehier/docker_images_ansible/>. There are images available for several distributions and versions. The distribution and version should be specified outside the script using environment variables:
+1. The script `docker-tests.sh` will create a Docker container, and apply this role from a playbook `<test.yml>`. The Docker images are configured for testing Ansible roles and are published at <https://hub.docker.com/r/bertvv/ansible-testing/>. There are images available for several distributions and versions. The distribution and version should be specified outside the script using environment variables:
 
     ```
-    DISTRIBUTION=centos VERSION=7 ANSIBLE_VERSION=2.5 ./docker-tests/docker-tests.sh
-    DISTRIBUTION=ubuntu VERSION=16.04 ANSIBLE_VERSION=2.5 ./docker-tests/docker-tests.sh
+    DISTRIBUTION=centos VERSION=7 ANSIBLE_VERSION=2.9 ./docker-tests/docker-tests.sh test_mono
+    DISTRIBUTION=ubuntu VERSION=18.04 ANSIBLE_VERSION=2.9 ./docker-tests/docker-tests.sh test_instances
     ```
-4. You can test another use case by adding an argument to the script. An argument `<another>` will apply a playbook `<another.yml>`
-
-5. You can run functionnal tests locally like that:
-
-    ```
-    SUT_ID=9acda29c356b ./docker-tests/functional-tests.sh
-    SUT_IP=172.17.0.2   ./docker-tests/functional-tests.sh
-    ```
-   
 The specific combinations of distributions and versions that are supported by this role are specified in `.travis.yml`.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,14 +3,14 @@ galaxy_info:
   author: Cedric DELGEHIER <cedric@openio.io>
   description: install an OpenIO rawx
   company: OpenIO
-  license: Apache
+  license: AGPLv3
 
-  min_ansible_version: 2.4
+  min_ansible_version: 2.9
 
   platforms:
     - name: Ubuntu
       versions:
-        - xenial
+        - bionic
     - name: EL
       versions:
         - 7

--- a/tasks/absent.yml
+++ b/tasks/absent.yml
@@ -2,10 +2,10 @@
 ---
 - name: absent - Reset defaults
   set_fact:
-    openio_rawx_servicename: "{{ rx.ansible_facts._rawx.name }}"
-    openio_rawx_bind_port: "{{ rx.ansible_facts._rawx.port }}"
-    openio_rawx_serviceid: "{{ rx.ansible_facts._rawx.id }}"
-    openio_rawx_volume: "{{ rx.ansible_facts._rawx.volume }}"
+    _openio_rawx_servicename: "{{ rx.ansible_facts._rawx.name }}"
+    _openio_rawx_bind_port: "{{ rx.ansible_facts._rawx.port }}"
+    _openio_rawx_serviceid: "{{ rx.ansible_facts._rawx.id }}"
+    _openio_rawx_volume: "{{ rx.ansible_facts._rawx.volume }}"
   tags:
     - install
     - configure
@@ -16,16 +16,16 @@
     state: absent
   with_items:
     - dest: "{{ openio_rawx_sysconfig_dir }}/\
-        {{ openio_rawx_servicename }}/{{ openio_rawx_servicename }}-httpd.conf"
+        {{ _openio_rawx_servicename }}/{{ _openio_rawx_servicename }}-httpd.conf"
     - dest: "{{ openio_rawx_gridinit_dir }}/{{ openio_rawx_gridinit_file_prefix }}\
-        {{ openio_rawx_servicename }}.conf"
-    - dest: "{{ openio_rawx_sysconfig_dir }}/watch/{{ openio_rawx_servicename }}.yml"
+        {{ _openio_rawx_servicename }}.conf"
+    - dest: "{{ openio_rawx_sysconfig_dir }}/watch/{{ _openio_rawx_servicename }}.yml"
   register: _rawx_conf
   tags: configure
 
 - block:
     - name: absent - stop rawx to apply the new configuration
-      shell: gridinit_cmd stop  {{ openio_rawx_namespace }}-{{ openio_rawx_servicename }}
+      shell: gridinit_cmd stop  {{ openio_rawx_namespace }}-{{ _openio_rawx_servicename }}
 
     - name: absent - Set properties
       set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -73,7 +73,7 @@
     - need_reload | default(false)
 
 - name: "restart rawx to apply the new configuration"
-  shell: gridinit_cmd restart  {{ openio_rawx_namespace }}-{{ openio_rawx_servicename }}
+  command: "gridinit_cmd restart  {{ openio_rawx_namespace }}-{{ item.ansible_facts._rawx.name }}"
   tags: configure
   with_items: "{{ _rawx_properties.results }}"
   when:
@@ -83,7 +83,7 @@
 
 - block:
     - name: "Ensure rawx is started"
-      command: gridinit_cmd start {{ openio_rawx_namespace }}-{{ item.ansible_facts._rawx.name }}
+      command: "gridinit_cmd start {{ openio_rawx_namespace }}-{{ item.ansible_facts._rawx.name }}"
       register: _start_rawx
       changed_when: '"Success" in _start_rawx.stdout'
       when: item.ansible_facts._rawx.state == "present"

--- a/tasks/offline.yml
+++ b/tasks/offline.yml
@@ -2,11 +2,11 @@
 ---
 - name: offline - Reset defaults
   set_fact:
-    openio_rawx_servicename: "{{ rx.ansible_facts._rawx.name }}"
-    openio_rawx_bind_port: "{{ rx.ansible_facts._rawx.port }}"
-    openio_rawx_serviceid: "{{ rx.ansible_facts._rawx.id }}"
-    openio_rawx_volume: "{{ rx.ansible_facts._rawx.volume }}"
-    openio_rawx_state: "{{ rx.ansible_facts._rawx.state }}"
+    _openio_rawx_servicename: "{{ rx.ansible_facts._rawx.name }}"
+    _openio_rawx_bind_port: "{{ rx.ansible_facts._rawx.port }}"
+    _openio_rawx_serviceid: "{{ rx.ansible_facts._rawx.id }}"
+    _openio_rawx_volume: "{{ rx.ansible_facts._rawx.volume }}"
+    _openio_rawx_state: "{{ rx.ansible_facts._rawx.state }}"
   tags:
     - install
     - configure
@@ -21,13 +21,13 @@
   with_items:
     - src: "gridinit_rawx.conf.j2"
       dest: "{{ openio_rawx_gridinit_dir }}/{{ openio_rawx_gridinit_file_prefix }}\
-        {{ openio_rawx_servicename }}.conf"
+        {{ _openio_rawx_servicename }}.conf"
   register: _rawx_conf
   tags: configure
 
 - block:
     - name: offline - stop rawx to apply the new configuration
-      shell: gridinit_cmd stop  {{ openio_rawx_namespace }}-{{ openio_rawx_servicename }}
+      shell: gridinit_cmd stop  {{ openio_rawx_namespace }}-{{ _openio_rawx_servicename }}
 
     - name: offline - Set properties
       set_fact:

--- a/tasks/present.yml
+++ b/tasks/present.yml
@@ -3,11 +3,13 @@
 
 - name: present - Reset defaults
   set_fact:
-    openio_rawx_servicename: "{{ rx.ansible_facts._rawx.name }}"
-    openio_rawx_bind_port: "{{ rx.ansible_facts._rawx.port }}"
-    openio_rawx_serviceid: "{{ rx.ansible_facts._rawx.id }}"
-    openio_rawx_volume: "{{ rx.ansible_facts._rawx.volume }}"
-    openio_rawx_state: "{{ rx.ansible_facts._rawx.state }}"
+    _openio_rawx_servicename: "{{ rx.ansible_facts._rawx.name }}"
+    _openio_rawx_bind_port: "{{ rx.ansible_facts._rawx.port }}"
+    _openio_rawx_serviceid: "{{ rx.ansible_facts._rawx.id }}"
+    _openio_rawx_volume: "{{ rx.ansible_facts._rawx.volume }}"
+    _openio_rawx_state: "{{ rx.ansible_facts._rawx.state }}"
+    _openio_rawx_location: "{{ openio_location_room | default ('') }}{{ openio_location_rack | default ('') }}\
+  {{ openio_location_server | default (ansible_hostname ~ '.') }}{{ rx.ansible_facts._rawx.id }}"
   tags:
     - install
     - configure
@@ -20,9 +22,9 @@
     group: "{{ item.group | default('openio') }}"
     mode: "{{ item.mode | default(0755) }}"
   with_items:
-    - path: "{{ openio_rawx_volume }}"
-    - path: "{{ openio_rawx_sysconfig_dir }}/{{ openio_rawx_servicename }}"
-    - path: "/var/log/oio/sds/{{ openio_rawx_namespace }}/{{ openio_rawx_servicename }}"
+    - path: "{{ _openio_rawx_volume }}"
+    - path: "{{ openio_rawx_sysconfig_dir }}/{{ _openio_rawx_servicename }}"
+    - path: "/var/log/oio/sds/{{ openio_rawx_namespace }}/{{ _openio_rawx_servicename }}"
       owner: "{{ syslog_user }}"
       mode: "0770"
   tags: install
@@ -37,12 +39,12 @@
   with_items:
     - src: "rawx.conf.j2"
       dest: "{{ openio_rawx_sysconfig_dir }}/\
-        {{ openio_rawx_servicename }}/{{ openio_rawx_servicename }}-httpd.conf"
+        {{ _openio_rawx_servicename }}/{{ _openio_rawx_servicename }}-httpd.conf"
     - src: "gridinit_rawx.conf.j2"
       dest: "{{ openio_rawx_gridinit_dir }}/{{ openio_rawx_gridinit_file_prefix }}\
-        {{ openio_rawx_servicename }}.conf"
+        {{ _openio_rawx_servicename }}.conf"
     - src: "watch-rawx.yml.j2"
-      dest: "{{ openio_rawx_sysconfig_dir }}/watch/{{ openio_rawx_servicename }}.yml"
+      dest: "{{ openio_rawx_sysconfig_dir }}/watch/{{ _openio_rawx_servicename }}.yml"
   register: _rawx_conf
   tags: configure
 

--- a/templates/gridinit_rawx.conf.j2
+++ b/templates/gridinit_rawx.conf.j2
@@ -1,10 +1,10 @@
 # {{ ansible_managed }}
-[Service.{{ openio_rawx_namespace }}-{{ openio_rawx_servicename }}]
-command={{ rawx_httpd_bin }} -D FOREGROUND -s OIO,{{ openio_rawx_namespace }},rawx,{{ openio_rawx_serviceid }} -f {{ openio_rawx_sysconfig_dir }}/{{ openio_rawx_servicename }}/{{ openio_rawx_servicename }}-httpd.conf
-enabled={{ 'false' if openio_rawx_state == 'offline' else 'true' }}
+[Service.{{ openio_rawx_namespace }}-{{ _openio_rawx_servicename }}]
+command={{ rawx_httpd_bin }} -D FOREGROUND -s OIO,{{ openio_rawx_namespace }},rawx,{{ _openio_rawx_serviceid }} -f {{ openio_rawx_sysconfig_dir }}/{{ _openio_rawx_servicename }}/{{ _openio_rawx_servicename }}-httpd.conf
+enabled={{ 'false' if _openio_rawx_state == 'offline' else 'true' }}
 start_at_boot=true
 on_die=respawn
-group={{ openio_rawx_namespace }},rawx,{{ openio_rawx_serviceid }}
+group={{ openio_rawx_namespace }},rawx,{{ _openio_rawx_serviceid }}
 uid=openio
 gid=openio
 env.PATH=/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin

--- a/templates/rawx.conf.j2
+++ b/templates/rawx.conf.j2
@@ -1,19 +1,19 @@
 # {{ ansible_managed }}
 Alias / /x/
 
-Listen          {{ openio_rawx_bind_address }}:{{ openio_rawx_bind_port }}
-PidFile         {{ openio_rawx_pid_directory }}/{{ openio_rawx_servicename }}-httpd.pid
+Listen          {{ openio_rawx_bind_address }}:{{ _openio_rawx_bind_port }}
+PidFile         {{ openio_rawx_pid_directory }}/{{ _openio_rawx_servicename }}-httpd.pid
 ServerRoot      /var/lib/oio/sds/{{ openio_rawx_namespace }}/coredump
 ServerName      localhost
 ServerSignature Off
 ServerTokens    Prod
-DocumentRoot    {{ openio_rawx_volume }}
+DocumentRoot    {{ _openio_rawx_volume }}
 TypesConfig     /etc/mime.types
 
 User  openio
 Group openio
 
-SetEnv INFO_SERVICES OIO,{{ openio_rawx_namespace }},rawx,{{ openio_rawx_serviceid }}
+SetEnv INFO_SERVICES OIO,{{ openio_rawx_namespace }},rawx,{{ _openio_rawx_serviceid }}
 SetEnv LOG_TYPE access
 SetEnv LEVEL INF
 SetEnv HOSTNAME {{ ansible_fqdn }}
@@ -26,10 +26,10 @@ SetEnvIf log-cid-in 0 !log-cid-in
 {% raw %}
 LogFormat "%{end:%b %d %T}t.%{end:usec_frac}t %{HOSTNAME}e %{INFO_SERVICES}e %{pid}P %{tid}P %{LOG_TYPE}e %{LEVEL}e %{Host}i %a:%{remote}p %m %>s %D %O %I - %{x-oio-req-id}i %U" log/req
 {% endraw %}
-ErrorLog /var/log/oio/sds/{{ openio_rawx_namespace }}/{{ openio_rawx_servicename }}/{{ openio_rawx_servicename }}-httpd-errors.log
+ErrorLog /var/log/oio/sds/{{ openio_rawx_namespace }}/{{ _openio_rawx_servicename }}/{{ _openio_rawx_servicename }}-httpd-errors.log
 SetEnvIf Request_URI "/(stat|info)$" nolog=1
 
-CustomLog /var/log/oio/sds/{{ openio_rawx_namespace }}/{{ openio_rawx_servicename }}/{{ openio_rawx_servicename }}-httpd-access.log log/req env=!nolog
+CustomLog /var/log/oio/sds/{{ openio_rawx_namespace }}/{{ _openio_rawx_servicename }}/{{ _openio_rawx_servicename }}-httpd-access.log log/req env=!nolog
 
 <IfModule worker.c>
 MaxRequestsPerChild {{ openio_rawx_mpm_max_requests_per_child }}
@@ -43,7 +43,7 @@ ThreadsPerChild {{ openio_rawx_mpm_threads_per_child }}
 
 DavDepthInfinity Off
 
-grid_docroot    {{ openio_rawx_volume }}
+grid_docroot    {{ _openio_rawx_volume }}
 # How many hexdigits must be used to name the indirection directories
 grid_hash_width  {{ openio_rawx_hash_width }}
 # How many levels of directories are used to store chunks
@@ -66,6 +66,6 @@ Require all granted
 Options -SymLinksIfOwnerMatch -FollowSymLinks -Includes -Indexes
 </Directory>
 
-<VirtualHost {{ openio_rawx_bind_address }}:{{ openio_rawx_bind_port }}>
+<VirtualHost {{ openio_rawx_bind_address }}:{{ _openio_rawx_bind_port }}>
 # DO NOT REMOVE (even if empty) !
 </VirtualHost>

--- a/templates/watch-rawx.yml.j2
+++ b/templates/watch-rawx.yml.j2
@@ -1,25 +1,25 @@
 # {{ ansible_managed }}
 ---
 host: {{ openio_rawx_bind_address }}
-port: {{ openio_rawx_bind_port }}
+port: {{ _openio_rawx_bind_port }}
 type: rawx
-{% if openio_rawx_location | ipaddr %}
-location: {{ openio_rawx_location | replace(".", "-") }}
+{% if _openio_rawx_location | ipaddr %}
+location: {{ _openio_rawx_location | replace(".", "-") }}
 {% else %}
 {% if  openio_rawx_location_ending %}
 {% if openio_rawx_location_ending == 'device_inode' %}
-location: {{ openio_rawx_location }}.{{ openio_rawx_volume | device_inode }}
+location: {{ _openio_rawx_location }}.{{  _openio_rawx_volume | device_inode }}
 {% elif openio_rawx_location_ending == 'mount_point' %}
-location: {{ openio_rawx_location }}.{{ openio_rawx_volume.split('/')[-1] }}
+location: {{ _openio_rawx_location }}.{{  _openio_rawx_volume.split('/')[-1] }}
 {% endif %}
 {% else %}
-location: {{ openio_rawx_location }}
+location: {{ _openio_rawx_location }}
 {% endif %}
 {% endif %}
 checks:
   - {type: http, uri: /info}
 stats:
-  - {type: volume, path: {{ openio_rawx_volume }}}
+  - {type: volume, path: {{  _openio_rawx_volume }}}
   - {type: rawx, path: /stat}
   - {type: system}
 slots:


### PR DESCRIPTION


 ##### SUMMARY

Previously, the role rewrote these variables:
  - openio_rawx_servicename
  - openio_rawx_bind_port
  - openio_rawx_serviceid
  - openio_rawx_volume
  - openio_rawx_state

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
The `/etc/oio/sds/NS/inventory.yml` was wrong, especially the port.