### PR TITLE
CHANGE(rawx): Change default of `gridinit_dir`, `gridinit_file_prefix…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,8 +10,8 @@ openio_rawx_serviceid: "0"
 openio_rawx_bind_port: 6200
 openio_rawx_volume: "/var/lib/oio/sds/{{ openio_rawx_namespace }}/{{ openio_rawx_servicename }}"
 
-openio_rawx_gridinit_dir: "/etc/gridinit.d/{{ openio_rawx_namespace }}"
-openio_rawx_gridinit_file_prefix: ""
+openio_rawx_gridinit_dir: "{{ openio_gridinit_d | d('/etc/gridinit.d/') }}"
+openio_rawx_gridinit_file_prefix: "{{ openio_rawx_namespace }}-"
 
 openio_rawx_pid_directory: "/run/oio/sds/{{ openio_rawx_namespace }}"
 # MPM worker
@@ -31,7 +31,7 @@ openio_rawx_compression: "off"
 openio_rawx_location: "{{ openio_location_room | default ('') }}{{ openio_location_rack | default ('') }}\
   {{ openio_location_server | default (ansible_hostname ~ '.') }}{{ openio_rawx_serviceid }}"
 openio_rawx_location_ending: ""
-openio_rawx_provision_only: false
+openio_rawx_provision_only: "{{ openio_maintenance_mode | d(false) | bool }}"
 openio_rawx_package_upgrade: "{{ openio_package_upgrade | d(false) }}"
 
 openio_rawx_slots:

--- a/docker-tests/test_instances.yml
+++ b/docker-tests/test_instances.yml
@@ -12,7 +12,7 @@
       openio_repository_mirror_host: mirror2.openio.io
     - role: gridinit
       openio_gridinit_namespace: "{{ NS }}"
-      openio_gridinit_per_ns: true
+      #openio_gridinit_per_ns: true
     - role: namespace
       openio_namespace_name: "{{ NS }}"
     - role: role_under_test

--- a/docker-tests/test_mono.yml
+++ b/docker-tests/test_mono.yml
@@ -12,7 +12,7 @@
       openio_repository_mirror_host: mirror2.openio.io
     - role: gridinit
       openio_gridinit_namespace: "{{ NS }}"
-      openio_gridinit_per_ns: true
+      #openio_gridinit_per_ns: true
     - role: namespace
       openio_namespace_name: "{{ NS }}"
     - role: role_under_test

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,7 +39,6 @@
         group: openio
         mode: "0755"
       with_items:
-        - "/etc/gridinit.d/{{ openio_rawx_namespace }}"
         - "/var/lib/oio/sds/{{ openio_rawx_namespace }}/coredump"
         - "{{ openio_rawx_pid_directory }}"
         - "/etc/oio/sds/{{ openio_rawx_namespace }}/watch"


### PR DESCRIPTION
…` and `provision_only`

 ##### SUMMARY

The playbook hardcode these calls. Now the defaults are good and there is no more hardcode.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION