### PR TITLE
CHANGE(rawx): Allow to set internal buffer sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Rawx is the storage service and is implemented as an apache webdav repository mo
 | `openio_rawx_bind_address` | `{ hostvars[inventory_hostname]['ansible_' + openio_rawx_bind_interface]['ipv4']['address'] }}` |  Address IP to use. |
 | `openio_rawx_bind_interface` | `"{{ ansible_default_ipv4.alias }}"` | Interface to use |
 | `openio_rawx_bind_port` | `6200` | Listening PORT |
+| `openio_rawx_buffer_size` | `0` | Size of the buffer receiving chunk data (kiB). 0 keeps the default set by the code. |
 | `openio_rawx_compression` | `"off"` | Compression mode |
 | `openio_rawx_fsync` | `enabled` | At the end of an upload, perform a fsync() on the chunk file itself |
 | `openio_rawx_fsync_dir` | `enabled` | At the end of an upload, perform a fsync() on the directory holding the chunk |
@@ -26,6 +27,7 @@ Rawx is the storage service and is implemented as an apache webdav repository mo
 | `openio_rawx_golang` | `false` | golang rawx |
 | `openio_rawx_hash_depth` | `1` | How many levels of directories are used to store chunks |
 | `openio_rawx_hash_width` | `3` | How many hexdigits must be used to name the indirection directories |
+| `openio_rawx_headers_buffer_size` | `0` | Size of the buffer receiving header data (bytes). 0 keeps the default set by the code |
 | `openio_rawx_location` | `"{{ openio_location_room | default ('') }}{{ openio_location_rack | default ('') }}{{ openio_location_server | default (ansible_hostname ~ '.') }}{{ openio_rawx_serviceid }}"` | Location |
 | `openio_rawx_location_ending` | `""` | ... |
 | `openio_rawx_mpm_max_requests_per_child` | `0` | set the total number of requests each child server process serves before the child dies |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,6 +31,9 @@ openio_rawx_fsync: disabled
 openio_rawx_fsync_dir: enabled
 openio_rawx_compression: "off"
 
+openio_rawx_buffer_size: 0
+openio_rawx_headers_buffer_size: 0
+
 openio_rawx_location: "{{ openio_location_room | default ('') }}{{ openio_location_rack | default ('') }}\
   {{ openio_location_server | default (ansible_hostname ~ '.') }}{{ openio_rawx_serviceid }}"
 openio_rawx_location_ending: ""

--- a/templates/rawx.conf.j2
+++ b/templates/rawx.conf.j2
@@ -73,6 +73,15 @@ grid_compression {{ openio_rawx_compression }}
 grid_namespace  {{ openio_rawx_namespace }}
 grid_dir_run    {{ openio_rawx_pid_directory }}
 
+{% if openio_rawx_golang %}
+{% if openio_rawx_buffer_size > 0 %}
+buffer_size         {{ openio_rawx_buffer_size }}
+{% endif %}
+{% if openio_rawx_headers_buffer_size > 0 %}
+headers_buffer_size {{ openio_rawx_headers_buffer_size }}
+{% endif %}
+{% endif %}
+
 <Directory />
 DAV rawx
 AllowOverride None


### PR DESCRIPTION
 ##### SUMMARY

Depending on the customer's workload, it may be useful to change the
internal buffer sizes. Benchmarks show that large buffer sizes are good
for big uploads, but may slow down small uploads.

As of 19.04 version, the internal chunk buffer is 2048 kiB long. For
workloads creating many chunks smaller than 1 MiB, it may be a good idea
to reduce it.

 ##### IMPACT
No impact unless the new variable is defined in customer's inventory.

 ##### ADDITIONAL INFORMATION