### PR TITLE
CHANGE(rawx): Disable `openio_rawx_fsync_dir` by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,7 +25,7 @@ openio_rawx_mpm_threads_per_child: 256
 openio_rawx_hash_width: 3
 openio_rawx_hash_depth: 1
 openio_rawx_fsync: disabled
-openio_rawx_fsync_dir: enabled
+openio_rawx_fsync_dir: disabled
 openio_rawx_compression: "off"
 
 openio_rawx_location: "{{ openio_location_room | default ('') }}{{ openio_location_rack | default ('') }}\


### PR DESCRIPTION
 ##### SUMMARY

Increase performance by stopping all sync

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION