### PR TITLE
FEATURE(rawx): Add TLS support for Gateway

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,11 +44,15 @@ openio_rawx_slots:
 
 openio_rawx_state: present
 
+openio_rawx_tls_cert_file: ""
+openio_rawx_tls_key_file: ""
+
 openio_rawx_instances:
   - id: "{{ openio_rawx_serviceid }}"
     port: "{{ openio_rawx_bind_port }}"
     volume: "{{ openio_rawx_volume }}"
     state: "{{ openio_rawx_state }}"
+    tls_url: "{{ openio_rawx_bind_address }}:{{ openio_rawx_bind_port }}"
 
 openio_rawx_sysconfig_dir: "/etc/oio/sds/{{ openio_rawx_namespace }}"
 openio_rawx_servicename: "rawx-{{ openio_rawx_serviceid }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,6 +24,8 @@
       id: "{{ item.1.id | default(item.0) }}"  # mandatory
       port: "{{ item.1.port }}"  # mandatory
       state: "{{ item.1.state | d('present') }}"
+      tls_url: "{{ item.1.tls_url | d(openio_rawx_bind_address ~ ':' ~ item.1.port) }}"
+
   with_indexed_items: "{{ openio_rawx_instances }}"
   register: _rawx_properties
   tags:

--- a/tasks/present.yml
+++ b/tasks/present.yml
@@ -8,6 +8,7 @@
     _openio_rawx_serviceid: "{{ rx.ansible_facts._rawx.id }}"
     _openio_rawx_volume: "{{ rx.ansible_facts._rawx.volume }}"
     _openio_rawx_state: "{{ rx.ansible_facts._rawx.state }}"
+    _openio_rawx_tls_url: "{{ rx.ansible_facts._rawx.tls_url }}"
     _openio_rawx_location: "{{ openio_location_room | default ('') }}{{ openio_location_rack | default ('') }}\
   {{ openio_location_server | default (ansible_hostname ~ '.') }}{{ rx.ansible_facts._rawx.id }}"
   tags:

--- a/templates/rawx.conf.j2
+++ b/templates/rawx.conf.j2
@@ -13,6 +13,12 @@ TypesConfig     /etc/mime.types
 User  openio
 Group openio
 
+{% if openio_rawx_tls_cert_file and openio_rawx_tls_key_file %}
+tls_cert_file {{ openio_rawx_tls_cert_file }}
+tls_key_file {{ openio_rawx_tls_key_file }}
+tls_rawx_url {{ _openio_rawx_tls_url }}
+{% endif %}
+
 SetEnv INFO_SERVICES OIO,{{ openio_rawx_namespace }},rawx,{{ _openio_rawx_serviceid }}
 SetEnv LOG_TYPE access
 SetEnv LEVEL INF

--- a/templates/watch-rawx.yml.j2
+++ b/templates/watch-rawx.yml.j2
@@ -16,6 +16,9 @@ location: {{ _openio_rawx_location }}.{{  _openio_rawx_volume.split('/')[-1] }}
 location: {{ _openio_rawx_location }}
 {% endif %}
 {% endif %}
+{% if openio_rawx_tls_cert_file and openio_rawx_tls_key_file %}
+tls: {{ _openio_rawx_tls_url }}
+{% endif %}
 checks:
   - {type: http, uri: /info}
 stats:


### PR DESCRIPTION
 ##### SUMMARY

It will be possible to use TLS between Gateway and RAWX.

At this time, certificate have to be provided by our customer.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
Please note that `tls_rawx_url` is not necessarily `openio_rawx_bind_address:openio_rawx_bind_port`