### PR TITLE
FEATURE(rawx): openio_rawx_events

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Rawx is the storage service and is implemented as an apache webdav repository mo
 | `openio_rawx_bind_port` | `6200` | Listening PORT |
 | `openio_rawx_buffer_size` | `0` | Size of the buffer receiving chunk data (kiB). 0 keeps the default set by the code. |
 | `openio_rawx_compression` | `"off"` | Compression mode |
+| `openio_rawx_events` | `true` | Events notifications |
 | `openio_rawx_fsync` | `enabled` | At the end of an upload, perform a fsync() on the chunk file itself |
 | `openio_rawx_fsync_dir` | `enabled` | At the end of an upload, perform a fsync() on the directory holding the chunk |
 | `openio_rawx_gridinit_dir` | `"/etc/gridinit.d/{{ openio_rawx_namespace }}"` | Path to copy the gridinit conf |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,7 @@ openio_rawx_hash_depth: 1
 openio_rawx_fsync: disabled
 openio_rawx_fsync_dir: disabled
 openio_rawx_compression: "off"
+openio_rawx_events: true
 
 openio_rawx_buffer_size: 8192
 openio_rawx_headers_buffer_size: 65536

--- a/templates/rawx.conf.j2
+++ b/templates/rawx.conf.j2
@@ -71,6 +71,7 @@ grid_fsync_dir  {{ openio_rawx_fsync_dir }}
 grid_compression {{ openio_rawx_compression }}
 grid_namespace  {{ openio_rawx_namespace }}
 grid_dir_run    {{ openio_rawx_pid_directory }}
+events          {{ openio_rawx_events | lower }}
 
 {% if openio_rawx_buffer_size > 0 %}
 buffer_size         {{ openio_rawx_buffer_size }}


### PR DESCRIPTION
 ##### SUMMARY

the `events` configuration elements to enable/disable sending events in
rawx. Default value is to activate events, this is the same as the
default value in code.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION