### PR TITLE
BUGFIX/MINOR(rawx): fix watch directory creation

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,7 +43,7 @@
       with_items:
         - "/var/lib/oio/sds/{{ openio_rawx_namespace }}/coredump"
         - "{{ openio_rawx_pid_directory }}"
-        - "/etc/oio/sds/{{ openio_rawx_namespace }}/watch"
+        - "{{ openio_rawx_sysconfig_dir }}/watch"
 
     - name: Ensure pid directory is persistant
       lineinfile:


### PR DESCRIPTION
 ##### SUMMARY

watch files directory was hardcoded to `/etc/oio/sds/xxx/watch` during
its creation but later on the watch file was written to
`openio_xxx_sysconfig_dir`/watch/xxxx.yml

which can cause a bug when openio_xxx_sysconfig_dir override default
value

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION